### PR TITLE
fix(ngx-alias): fixes incorrect `T | null` in AsyncPipe bool comparison

### DIFF
--- a/projects/ngx-structurals/src/lib/ngx-alias/ngx-alias.directive.ts
+++ b/projects/ngx-structurals/src/lib/ngx-alias/ngx-alias.directive.ts
@@ -13,14 +13,15 @@ export class NgxAliasContext<T> {
      *
      * @publicApi
      */
-    public ngxAlias: T | null = null;
+    // tslint:disable-next-line: no-non-null-assertion justification https://github.com/angular/vscode-ng-language-service/issues/1137
+    public ngxAlias: T = null!;
 
     /**
      * Synonym for {@link ngxAlias}.
      *
      * @publicApi
      */
-    public get $implicit(): T | null {
+    public get $implicit(): T {
         return this.ngxAlias;
     }
 }


### PR DESCRIPTION
example
```ts
*ngxAlias="(isLoading$ | async) === true as isLoading"
```
would result in in `isLoading` being `true | false | null`.
Now it correctly infers the type `boolean`

fixes #37